### PR TITLE
Suppor for scala binary versions 2.11 and 2.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The project is written in Java 8.
        <artifactId>spark-utils_2.10</artifactId>
        <version>1.0.1</version>
    </dependency>
+```
+```xml
    <dependency>
        <groupId>pl.edu.icm.spark-utils</groupId>
        <artifactId>spark-utils_2.11</artifactId>

--- a/README.md
+++ b/README.md
@@ -19,10 +19,16 @@ The project is written in Java 8.
 ```xml
    <dependency>
        <groupId>pl.edu.icm.spark-utils</groupId>
-       <artifactId>spark-utils</artifactId>
-       <version>1.0.0</version>
+       <artifactId>spark-utils_2.10</artifactId>
+       <version>1.0.1</version>
+   </dependency>
+   <dependency>
+       <groupId>pl.edu.icm.spark-utils</groupId>
+       <artifactId>spark-utils_2.11</artifactId>
+       <version>1.0.1</version>
    </dependency>
 ```
+Remember to choose scala binary version matching your project's scala binary version.
 
 ## Support for testing spark jobs
 To test a spark job written in java (or scala) you have to run a java main class which contains the job definition. Usually you'll want to pass some arguments to it (spark application name, job parameters) to configure the job properly.
@@ -43,7 +49,6 @@ How can you write a test of a spark job by using *spark-utils*? Just see the exa
     @Test
     public void peopleClonerJob() throws IOException {
         
-        
         //------------------------ given -----------------------------
         
         // prepare some data and params
@@ -53,22 +58,16 @@ How can you write a test of a spark job by using *spark-utils*? Just see the exa
         // configure a job
         SparkJob sparkJob = SparkJobBuilder
                                            .create()
-                                           
                                            .setAppName("Spark People Cloner")
-        
                                            .setMainClass(SparkPeopleCloner.class) // main class with the job definition
-                                           
                                            .addArg("-inputPath", inputDirPath)
                                            .addArg("-outputPath", outputDirPath)
                                            .addArg("-numberOfCopies", "3")
-                                           
                                            .build();
-        
         
         //------------------------ execute -----------------------------
         
         executor.execute(sparkJob); // execute the job
-        
         
         //------------------------ assert -----------------------------
         
@@ -78,10 +77,7 @@ How can you write a test of a spark job by using *spark-utils*? Just see the exa
         // assert the result is ok
         assertEquals(15, people.size());
         assertEquals(3, people.stream().filter(p->p.getName().equals(new Utf8("Stieg Larsson"))).count());
-        
     }
-
-
 ```
 You may also be interested in seeing real production code that uses *spark-utils* to test spark jobs. Here is an example from [IIS](https://github.com/openaire/iis) project: [AffMatchingJobTest](https://github.com/openaire/iis/blob/cdh5/iis-wf/iis-wf-affmatching/src/test/java/eu/dnetlib/iis/wf/affmatching/AffMatchingJobTest.java)
 
@@ -111,8 +107,6 @@ To eliminate this phenomenon, one should clone each avro record after it has bee
 
 In addition, you get a simpler API that is easy to use.
 
-
-
 ### Writing avro files
 To write a spark JavaRDD to avro files, import [SparkAvroSaver](https://github.com/CeON/spark-utils/blob/master/src/main/java/pl/edu/icm/sparkutils/avro/SparkAvroSaver.java) and use its **saveJavaRDD** or **saveJavaPairRDDKeys**, for example:
 
@@ -124,7 +118,6 @@ sparkAvroSaver.saveJavaRDD(javaRDD, avroSchema, outputPath);
 where:
 * *avroSchema* is an avro schema of objects that will be saved
 * *outputPath* points to a place where the avro files will be saved
-
 
 ### Using avro in [Kryo](https://github.com/EsotericSoftware/kryo)
 
@@ -138,6 +131,3 @@ SparkConf conf = new SparkConf();
 conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
 conf.set("spark.kryo.registrator", "pl.edu.icm.sparkutils.avro.AvroCompatibleKryoRegistrator");
 ...
-```
-
-

--- a/pom.xml
+++ b/pom.xml
@@ -1,155 +1,116 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>pl.edu.icm.spark-utils</groupId>
-	<artifactId>spark-utils</artifactId>
-	<version>1.0.1-SNAPSHOT</version>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>pl.edu.icm.spark-utils</groupId>
+    <artifactId>spark-utils</artifactId>
+    <version>1.0.1-SNAPSHOT</version>
 
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
 
-	<licenses>
-		<license>
-			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-		</license>
-	</licenses>
+    <scm>
+        <connection>scm:git:ssh://git@github.com/CeON/spark-utils.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/CeON/spark-utils.git</developerConnection>
+        <url>https://github.com/CeON/spark-utils</url>
+        <tag>HEAD</tag>
+    </scm>
 
-	<scm>
-		<connection>scm:git:ssh://git@github.com/CeON/spark-utils.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com/CeON/spark-utils.git</developerConnection>
-		<url>https://github.com/CeON/spark-utils</url>
-	  <tag>HEAD</tag>
-  </scm>
+    <distributionManagement>
+        <repository>
+            <id>ceon-commons-releases</id>
+            <url>http://maven.ceon.pl/artifactory/ceon-commons-releases</url>
+        </repository>
+        <snapshotRepository>
+            <id>ceon-commons-snapshots</id>
+            <url>http://maven.ceon.pl/artifactory/ceon-commons-snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
 
-        <distributionManagement>
-                <repository>
-                        <id>ceon-commons-releases</id>
-                        <url>http://maven.ceon.pl/artifactory/ceon-commons-releases</url>
-                </repository>
-                <snapshotRepository>
-                        <id>ceon-commons-snapshots</id>
-                        <url>http://maven.ceon.pl/artifactory/ceon-commons-snapshots</url>
-                </snapshotRepository>
-        </distributionManagement>
+    <repositories>
+        <repository>
+            <id>ceon</id>
+            <url>https://maven.ceon.pl/artifactory/repo/</url>
+        </repository>
+    </repositories>
 
-	<repositories>
-
-		<repository>
-			<id>ceon</id>
-			<url>https://maven.ceon.pl/artifactory/repo/</url>
-		</repository>
-
-	</repositories>
-
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.4.0</spark.version>
+    </properties>
 
     <dependencies>
-        
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.12</version>
-                <scope>test</scope>
-            </dependency>
-        
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>1.10.19</version>
-                <scope>test</scope>
-            </dependency>
-        
-        
-           <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.4</version>
-           </dependency>
-           
-           <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>18.0</version> 
-            </dependency>
-            
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-core</artifactId>
-                <version>4.2.3.RELEASE</version>
-            </dependency>
-            
-            <dependency>
-                <groupId>org.apache.spark</groupId>
-                <artifactId>spark-core_2.10</artifactId>
-                <version>1.5.2</version>
-            </dependency>
-            
-            <dependency>
-                <groupId>org.apache.spark</groupId>
-                <artifactId>spark-sql_2.10</artifactId>
-                <version>1.5.2</version>
-            </dependency>
-            
-             <dependency>
-                <groupId>org.apache.avro</groupId>
-                <artifactId>avro</artifactId>
-                <version>1.7.7</version>
-            </dependency>
-            
- 
-            
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>4.2.3.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
-    
-	<build>
 
-		<plugins>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.3</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-					<encoding>${project.build.sourceEncoding}</encoding>
-				</configuration>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.6</version>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>2.4</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>jar-no-fork</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.5.3</version>
             </plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.18.1</version>
-			</plugin>
-
-            <!-- Plugin that generates Java classes from Avro schemas -->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <!-- Plugin that generates Java classes from Avro schemas -->
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro-maven-plugin</artifactId>
-                <version>1.7.4</version>
+                <version>1.7.7</version>
                 <executions>
                     <execution>
                         <phase>generate-test-sources</phase>
@@ -165,10 +126,10 @@
                     </execution>
                 </executions>
             </plugin>
-            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>add-source</id>
@@ -183,16 +144,107 @@
                         </configuration>
                     </execution>
                 </executions>
-             </plugin>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <finalName>${project.artifactId}_${scala.binary.version}-${project.version}</finalName>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-pom</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/${scala.binary.version}
+                            </outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}</directory>
+                                    <includes>
+                                        <include>pom.xml</include>
+                                    </includes>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <id>replace-artifactid</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>target/${scala.binary.version}/pom.xml</file>
+                            <token>&lt;artifactId&gt;${project.artifactId}&lt;/artifactId&gt;</token>
+                            <value>&lt;artifactId&gt;${project.artifactId}_${scala.binary.version}&lt;/artifactId&gt;
+                            </value>
+                            <outputDir>target/${scala.binary.version}/replacer</outputDir>
+                            <outputFile>pom.xml</outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>2.5.2</version>
+                <executions>
+                    <execution>
+                        <id>default-install</id>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>install-scala-version</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+                            <version>${project.version}</version>
+                            <packaging>${project.packaging}</packaging>
+                            <file>${project.build.directory}/${project.artifactId}_${scala.binary.version}-${project.version}.jar</file>
+                            <pomFile>${project.build.directory}/${scala.binary.version}/replacer/pom.xml
+                            </pomFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
+    </build>
 
-	</build>
-
-
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-	</properties>
+    <profiles>
+        <profile>
+            <id>scala-2.10</id>
+            <properties>
+                <scala.binary.version>2.10</scala.binary.version>
+                <spark.version>1.5.2</spark.version>
+            </properties>
+        </profile>
+    </profiles>
 
 </project>
-

--- a/pom.xml
+++ b/pom.xml
@@ -196,8 +196,7 @@
                         <configuration>
                             <file>target/${scala.binary.version}/pom.xml</file>
                             <token>&lt;artifactId&gt;${project.artifactId}&lt;/artifactId&gt;</token>
-                            <value>&lt;artifactId&gt;${project.artifactId}_${scala.binary.version}&lt;/artifactId&gt;
-                            </value>
+                            <value>&lt;artifactId&gt;${project.artifactId}_${scala.binary.version}&lt;/artifactId&gt;</value>
                             <outputDir>target/${scala.binary.version}/replacer</outputDir>
                             <outputFile>pom.xml</outputFile>
                         </configuration>
@@ -228,8 +227,7 @@
                             <version>${project.version}</version>
                             <packaging>${project.packaging}</packaging>
                             <file>${project.build.directory}/${project.artifactId}_${scala.binary.version}-${project.version}.jar</file>
-                            <pomFile>${project.build.directory}/${scala.binary.version}/replacer/pom.xml
-                            </pomFile>
+                            <pomFile>${project.build.directory}/${scala.binary.version}/replacer/pom.xml</pomFile>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
This PR adds support for scala binary version `2.11` (used in spark `2.*`) and keeps support for scala binary version `2.10` (used in spark `1.*`) as a profile. This is necessary to use this project in spark `2.*` projects, which depend on scala version `2.11`. Spark dependency is also scoped as `provided` to avoid locking to specific spark version and allows to use this project artifact in cluster environments.

Additionally inside this PR:
- maven plugins update
- removal of unused dependencies
- readme reformatting

Approving this PR should be followed by a release of project's artifacts.